### PR TITLE
fix(ci): bootstrap terraform imports for github infra

### DIFF
--- a/.github/scripts/post-to-linkedin.js
+++ b/.github/scripts/post-to-linkedin.js
@@ -14,14 +14,17 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FRONTMATTER_BLOCK_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
+const FRONTMATTER_LINE_SPLIT_REGEX = /\r?\n/;
+const TRAILING_SLASH_REGEX = /\/$/;
 
 /** Parse the YAML front-matter block at the top of a markdown file. */
 function parseFrontmatter(content) {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const match = content.match(FRONTMATTER_BLOCK_REGEX);
   if (!match) return null;
 
   const data = {};
-  for (const line of match[1].split(/\r?\n/)) {
+  for (const line of match[1].split(FRONTMATTER_LINE_SPLIT_REGEX)) {
     const colonIdx = line.indexOf(":");
     if (colonIdx === -1) continue;
 
@@ -117,7 +120,7 @@ async function postToLinkedIn(article) {
 
   const websiteUrl = (
     process.env.WEBSITE_URL || "https://lorenzogm.com"
-  ).replace(/\/$/, "");
+  ).replace(TRAILING_SLASH_REGEX, "");
   const articleUrl = `${websiteUrl}/blog/${article.slug}`;
 
   const postText = `${article.excerpt}\n\n${articleUrl}`;

--- a/.github/workflows/github-infra-deploy.yml
+++ b/.github/workflows/github-infra-deploy.yml
@@ -82,6 +82,30 @@ jobs:
         run: |
           terraform init
 
+      - name: Bootstrap Terraform state from existing GitHub resources
+        working-directory: infra/github/src
+        run: |
+          # If state already exists, skip imports.
+          if terraform state list >/dev/null 2>&1 && [ -n "$(terraform state list)" ]; then
+            echo "Terraform state already populated; skipping bootstrap imports."
+            exit 0
+          fi
+
+          REPO_NAME=$(jq -r '.repository.name' config.json)
+          if [ -z "$REPO_NAME" ] || [ "$REPO_NAME" = "null" ]; then
+            echo "::error::Could not resolve repository.name from config.json"
+            exit 1
+          fi
+
+          echo "Importing existing repository: $REPO_NAME"
+          terraform import github_repository.main "$REPO_NAME" || true
+
+          echo "Importing existing labels from config.json"
+          jq -r '.labels[].name' config.json | while read -r label; do
+            [ -z "$label" ] && continue
+            terraform import "github_issue_label.labels[\"$label\"]" "$REPO_NAME:$label" || true
+          done
+
       - name: Terraform Plan
         working-directory: infra/github/src
         id: plan

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-checks:
     runs-on: ubuntu-latest
-    name: Code Quality Checks
+    name: PR Checks
     permissions:
       contents: read
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -12,7 +12,6 @@
       "suspicious": {},
       "a11y": {},
       "performance": {
-        "useTopLevelRegex": "off",
         "noImgElement": "off"
       },
       "security": {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -12,7 +12,6 @@
       "suspicious": {},
       "a11y": {},
       "performance": {
-        "noImgElement": "off"
       },
       "security": {
         "noDangerouslySetInnerHtml": "off"

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -12,6 +12,8 @@
       "suspicious": {},
       "a11y": {},
       "performance": {
+        "useTopLevelRegex": "off",
+        "noImgElement": "off"
       },
       "security": {
         "noDangerouslySetInnerHtml": "off"

--- a/infra/github/src/.terraform.lock.hcl
+++ b/infra/github/src/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.2.1"
+  constraints = "6.2.1"
+  hashes = [
+    "h1:uDerb9YJo3vAO+wKw+Z064InX5aXom+nKLDry2eGf14=",
+    "zh:172aa5141c525174f38504a0d2e69d0d16c0a0b941191b7170fe6ae4d7282e30",
+    "zh:1a098b731fa658c808b591d030cc17cc7dfca1bf001c3c32e596f8c1bf980e9f",
+    "zh:245d6a1c7e632d8ae4bdd2da2516610c50051e81505cf420a140aa5fa076ea90",
+    "zh:43c61c230fb4ed26ff1b04b857778e65be3d8f80292759abbe2a9eb3c95f6d97",
+    "zh:59bb7dd509004921e4322a196be476a2f70471b462802f09d03d6ce96f959860",
+    "zh:5cb2ab8035d015c0732107c109210243650b6eb115e872091b0f7b98c2763777",
+    "zh:69d2a6acfcd686f7e859673d1c8a07fc1fc1598a881493f19d0401eb74c0f325",
+    "zh:77f36d3f46911ace5c50dee892076fddfd64a289999a5099f8d524c0143456d1",
+    "zh:87df41097dfcde72a1fbe89caca882af257a4763c2e1af669c74dcb8530f9932",
+    "zh:899dbe621f32d58cb7c6674073a6db8328a9db66eecfb0cc3fc13299fd4e62e7",
+    "zh:ad2eb7987f02f7dd002076f65a685730705d04435313b5cf44d3a6923629fb29",
+    "zh:b2145ae7134dba893c7f74ad7dfdc65fdddf6c7b1d0ce7e2f3baa96212322fd8",
+    "zh:bd6bae3ac5c3f96ad9219d3404aa006ef1480e9041d4c95df1808737e37d911b",
+    "zh:e89758b20ae59f1b9a6d32c107b17846ddca9634b868cf8f5c927cbb894b1b1f",
+  ]
+}


### PR DESCRIPTION
This PR makes github-infra-deploy idempotent on an existing repository by importing existing GitHub resources (repository + labels) when Terraform state is empty before plan/apply.